### PR TITLE
Play local mp3 files for people themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ DBWS.code-workspace
 settings.js
 /dist
 /afk-pics
+/audio

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"cross-env": "^10.0.0",
 				"csgo-predict-api": "^1.1.8",
 				"discord-api-types": "^0.38.21",
-				"discord-player": "^7.1.0",
+				"discord-player": "^7.2.0-dev.2",
 				"discord-player-youtubei": "^1.5.0",
 				"discord.js": "^14.22.1",
 				"discordx": "^11.12.6",
@@ -5746,9 +5746,9 @@
 			"integrity": "sha512-E6KtXUNjZVIYP1GMjmeRdAC1xRql9xtSahRwJYpP74/hJ6Q2i2oTp6ZbFG/FUN0WqtdW2igHDsJyF2u9hV8pHQ=="
 		},
 		"node_modules/discord-player": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/discord-player/-/discord-player-7.1.0.tgz",
-			"integrity": "sha512-bnEfvx5Ui0jLQjBw/17q8iYlw9C5aAjLiJ8379GQeF3Ln8ddeKRphAvthlKHBmq48aMySARwSxxL8147kQykyA==",
+			"version": "7.2.0-dev.2",
+			"resolved": "https://registry.npmjs.org/discord-player/-/discord-player-7.2.0-dev.2.tgz",
+			"integrity": "sha512-WwNu/Z/XDYVpzQNqEqcOdzJEaIAQ40loDO+pUsXGE++5mcfM7KYaVJuJC86w4Gh6PnSIpmMQ1d2IatdySfSKBg==",
 			"license": "MIT",
 			"dependencies": {
 				"@discord-player/equalizer": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"cross-env": "^10.0.0",
 		"csgo-predict-api": "^1.1.8",
 		"discord-api-types": "^0.38.21",
-		"discord-player": "^7.1.0",
+		"discord-player": "^7.2.0-dev.2",
 		"discord-player-youtubei": "^1.5.0",
 		"discord.js": "^14.22.1",
 		"discordx": "^11.12.6",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,13 +79,12 @@ export const SEVEN_EMOJI = "7️⃣";
 export const EIGHT_EMOJI = "8️⃣";
 export const NINE_EMOJI = "9️⃣";
 
-export const L_THEME_URL = "https://www.youtube.com/watch?v=qR6dzwQahOM";
-export const GHOST_TRAIN_ROBBERY = "https://www.youtube.com/watch?v=jgWziW2iNjE";
-export const TOXIC_URL = "https://www.youtube.com/watch?v=LOZuxwVk7TU";
-export const PLAYER_SITES = ["spotify", "youtube", "youtu.be", "soundcloud"];
 // TODO: Standardize paths
 export const SRC_DIR = path.resolve(`${dirname}`);
 export const PROJECT_DIR = path.dirname(SRC_DIR);
+
+export const L_THEME_URL = "https://www.youtube.com/watch?v=qR6dzwQahOM";
+export const PLAYER_SITES = ["spotify", "youtube", "youtu.be", "soundcloud"];
 
 export const TYPE_SPEED_RESET_TIME = 30 * 1000;
 export const TYPESCRIPT_URL = "https://i.imgur.com/PUkCMgu.png";

--- a/src/events/voiceStateUpdate/people-themes.ts
+++ b/src/events/voiceStateUpdate/people-themes.ts
@@ -1,16 +1,26 @@
 import { ArgsOf, Discord, On } from "discordx";
-import { DANIEL_ID, GHOST_TRAIN_ROBBERY, JUSTIN_M_ID, TOXIC_URL } from "../../constants.js";
+import { DANIEL_ID, JUSTIN_M_ID, PROJECT_DIR } from "../../constants.js";
 import { tryPlayPersonTheme } from "../../util/person-theme-helpers.js";
 
 const JUSTIN_THEME_CHANCE = 1;
 const TOXIC_THEME_CHANCE = 1;
+
+export const GHOST_TRAIN_ROBBERY_FILE_PATH = `${PROJECT_DIR}/audio/ghost-train-robbery.mp3`;
+export const TOXIC_FILE_PATH = `${PROJECT_DIR}/audio/toxic.mp3`;
 
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class PeopleThemes {
 	@On({ event: "voiceStateUpdate" })
 	private async tryPlayThemes([oldState, newState]: ArgsOf<"voiceStateUpdate">) {
-		await tryPlayPersonTheme(JUSTIN_M_ID, JUSTIN_THEME_CHANCE, GHOST_TRAIN_ROBBERY, oldState, newState);
-		await tryPlayPersonTheme(DANIEL_ID, TOXIC_THEME_CHANCE, TOXIC_URL, oldState, newState, 68400);
+		await tryPlayPersonTheme(
+			JUSTIN_M_ID,
+			JUSTIN_THEME_CHANCE,
+			GHOST_TRAIN_ROBBERY_FILE_PATH,
+			oldState,
+			newState,
+			Math.floor(Math.random() * 43060)
+		);
+		await tryPlayPersonTheme(DANIEL_ID, TOXIC_THEME_CHANCE, TOXIC_FILE_PATH, oldState, newState);
 	}
 }

--- a/src/types/containers/bot-container.ts
+++ b/src/types/containers/bot-container.ts
@@ -90,20 +90,15 @@ export class BDBot {
 	}
 
 	private async initPlayer(client: Client) {
-		this.player = new Player(client, {
-			// ytdlOptions: {
-			// 	quality: "lowestaudio",
-			// 	filter: "audioonly",
-			// 	// eslint-disable-next-line no-bitwise
-			// 	highWaterMark: 1 << 25,
-			// },
-		});
+		this.player = new Player(client, {});
 
 		await this.player.extractors.loadMulti(DefaultExtractors);
 		await this.player.extractors.register(YoutubeiExtractor, {});
 
 		this.player.events.on("playerStart", async (queue: GuildQueue<{ channel: TextChannel }>, track: Track) => {
-			await queue.metadata.channel.send(`:notes: | Now playing **${track.title}**!`);
+			if (queue.metadata?.channel !== undefined) {
+				await queue.metadata.channel.send(`:notes: | Now playing **${track.title}**!`);
+			}
 		});
 
 		this.player.on("error", (error: Error) => {


### PR DESCRIPTION
closes #77 

Use discord-player to play local audio files for our people-themes event. Added audio folder ignored by git due to avoid uploading audio files to github. Note: For developers without these files that somehow trigger this event, an error will be caught and printed to console.

Additionally, minor discord-player changes and fixes.