### PR TITLE
refactor(events): use BD5Only guard for BD5 server-only event handlers

### DIFF
--- a/src/events/messageCreate/christina-polls.ts
+++ b/src/events/messageCreate/christina-polls.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import { ArgsOf, Discord, On } from "discordx";
+import { ArgsOf, Discord, Guard, On } from "discordx";
 import {
 	CHRISTINA_POLLS_CHANNEL_ID,
 	EIGHT_EMOJI,
@@ -13,6 +13,7 @@ import {
 	TWO_EMOJI,
 } from "../../constants.js";
 import { tryReactMessage } from "../../util/message-helper.js";
+import { BD5Only } from "../../util/guards.js";
 
 const numToUnicodeEmojiMap: Map<number, string> = new Map([
 	[1, ONE_EMOJI],
@@ -29,6 +30,7 @@ const numToUnicodeEmojiMap: Map<number, string> = new Map([
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class ChristinaPolls {
+	@Guard(BD5Only)
 	@On({ event: "messageCreate" })
 	private async tryReactPoll([msg]: ArgsOf<"messageCreate">) {
 		if (msg.channelId === CHRISTINA_POLLS_CHANNEL_ID) {

--- a/src/events/messageCreate/daniel-ty.ts
+++ b/src/events/messageCreate/daniel-ty.ts
@@ -1,9 +1,11 @@
-import { ArgsOf, Discord, On } from "discordx";
+import { ArgsOf, Discord, Guard, On } from "discordx";
 import { DANIEL_ID } from "../../constants.js";
+import { BD5Only } from "../../util/guards.js";
 
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class DanielTy {
+	@Guard(BD5Only)
 	@On({ event: "messageCreate" })
 	private async handleDanielTy([msg]: ArgsOf<"messageCreate">) {
 		const { channel } = msg;

--- a/src/events/messageCreate/khang-neko.ts
+++ b/src/events/messageCreate/khang-neko.ts
@@ -1,16 +1,18 @@
-import { ArgsOf, Discord, On } from "discordx";
+import { ArgsOf, Discord, Guard, On } from "discordx";
 import { client } from "../../app.js";
-import { BD5_ID, KHANG_ID, KHANG_NEKO_EMOJI_ID } from "../../constants.js";
+import { KHANG_ID, KHANG_NEKO_EMOJI_ID } from "../../constants.js";
 import { random, tryReactMessage } from "../../util/index.js";
+import { BD5Only } from "../../util/guards.js";
 
 const KHANG_NEKO_CHANCE = 0.5;
 
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class KhangNeko {
+	@Guard(BD5Only)
 	@On({ event: "messageCreate" })
 	private async tryKhangNeko([msg]: ArgsOf<"messageCreate">) {
-		if (msg.author.id !== KHANG_ID || msg.guildId !== BD5_ID) return;
+		if (msg.author.id !== KHANG_ID) return;
 		const KHANG_NEKO_EMOJI = client.emojis.cache.get(KHANG_NEKO_EMOJI_ID);
 
 		if (random(KHANG_NEKO_CHANCE) && KHANG_NEKO_EMOJI) {

--- a/src/events/messageCreate/zach-zacc.ts
+++ b/src/events/messageCreate/zach-zacc.ts
@@ -1,5 +1,6 @@
-import { ArgsOf, Discord, On } from "discordx";
+import { ArgsOf, Discord, Guard, On } from "discordx";
 import { random } from "../../util/index.js";
+import { BD5Only } from "../../util/guards.js";
 
 const ZACC_CHANCE = 7.5;
 const ZACH_REGEX = /[Zz][Aa][Cc][Hh]/gm;
@@ -7,6 +8,7 @@ const ZACH_REGEX = /[Zz][Aa][Cc][Hh]/gm;
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class ZachZacc {
+	@Guard(BD5Only)
 	@On({ event: "messageCreate" })
 	private async handleZachZacc([msg]: ArgsOf<"messageCreate">) {
 		const { content } = msg;

--- a/src/events/presenceUpdate/holiday-colors.ts
+++ b/src/events/presenceUpdate/holiday-colors.ts
@@ -1,4 +1,4 @@
-import { ArgsOf, Discord, On } from "discordx";
+import { ArgsOf, Discord, Guard, On } from "discordx";
 import { Presence } from "discord.js";
 import {
 	BD5_ID,
@@ -13,6 +13,7 @@ import {
 } from "../../constants.js";
 import { client } from "../../app.js";
 import { getRandomElement, isNullOrUndefined } from "../../util/index.js";
+import { BD5Only } from "../../util/guards.js";
 
 export enum Month {
 	January = 0,
@@ -46,10 +47,10 @@ const UPDATE_DATE_PERIOD_MS = 6 * 60 * 60 * 1000;
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class HolidayColors {
+	@Guard(BD5Only)
 	@On({ event: "presenceUpdate" })
 	private async updateHolidayColors([oldPresence, newPresence]: ArgsOf<"presenceUpdate">) {
 		if (!oldPresence || !newPresence) return;
-		if (oldPresence.guild.id !== BD5_ID) return;
 
 		const currDate = new Date();
 		if (!holidayRoleMap.has(currDate.getMonth())) {

--- a/src/events/typingStart/type-speed-watcher.ts
+++ b/src/events/typingStart/type-speed-watcher.ts
@@ -1,10 +1,12 @@
-import { ArgsOf, Discord, On } from "discordx";
+import { ArgsOf, Discord, Guard, On } from "discordx";
 import { bdbot } from "../../app.js";
 import { TYPE_SPEED_RESET_TIME } from "../../constants.js";
+import { BD5Only } from "../../util/guards.js";
 
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class TypeSpeedWatcher {
+	@Guard(BD5Only)
 	@On({ event: "typingStart" })
 	private async watchTypeState([typingState]: ArgsOf<"typingStart">) {
 		const userId = typingState.user.id;

--- a/src/events/voiceStateUpdate/asian-kyle-random-mute.ts
+++ b/src/events/voiceStateUpdate/asian-kyle-random-mute.ts
@@ -1,12 +1,14 @@
-import { ArgsOf, Discord, On } from "discordx";
+import { ArgsOf, Discord, Guard, On } from "discordx";
 import { ASIAN_KYLE_ID } from "../../constants.js";
 import { random } from "../../util/index.js";
+import { BD5Only } from "../../util/guards.js";
 
 const MUTE_ASIAN_KYLE_CHANCE = 0;
 
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class AsianKyleRandomMute {
+	@Guard(BD5Only)
 	@On({ event: "voiceStateUpdate" })
 	private async tryMute([oldState, newState]: ArgsOf<"voiceStateUpdate">) {
 		const memberId = oldState.member.id;

--- a/src/events/voiceStateUpdate/good-night.ts
+++ b/src/events/voiceStateUpdate/good-night.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
 import { EmbedBuilder, GuildMember, TextChannel } from "discord.js";
-import { ArgsOf, Discord, On } from "discordx";
+import { ArgsOf, Discord, Guard, On } from "discordx";
 import { client } from "../../app.js";
-import { BD5_BOT_STUFF_CHANNEL_ID, BD5_ID } from "../../constants.js";
+import { BD5_BOT_STUFF_CHANNEL_ID } from "../../constants.js";
 import {
 	getRandomElement,
 	hasHumans,
@@ -11,6 +11,7 @@ import {
 	random,
 	sendErrorToDiscordChannel,
 } from "../../util/index.js";
+import { BD5Only } from "../../util/guards.js";
 
 const GOOD_NIGHT_VARIATIONS = [
 	"goot!",
@@ -37,9 +38,10 @@ async function randomGifUrl(lmt, searchString) {
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class GoodNight {
+	@Guard(BD5Only)
 	@On({ event: "voiceStateUpdate" })
 	private async tryGoodNight([oldState, newState]: ArgsOf<"voiceStateUpdate">) {
-		if (newState.guild.id !== BD5_ID || newState.member.user.bot) return;
+		if (newState.member.user.bot) return;
 
 		// TODO: We need a guild config that allows us to use bot_stuff channels more generally
 		const botStuffChannel = client.channels.resolve(BD5_BOT_STUFF_CHANNEL_ID) as TextChannel;

--- a/src/events/voiceStateUpdate/people-themes.ts
+++ b/src/events/voiceStateUpdate/people-themes.ts
@@ -1,6 +1,7 @@
-import { ArgsOf, Discord, On } from "discordx";
+import { ArgsOf, Discord, Guard, On } from "discordx";
 import { DANIEL_ID, JUSTIN_M_ID, PROJECT_DIR } from "../../constants.js";
 import { tryPlayPersonTheme } from "../../util/person-theme-helpers.js";
+import { BD5Only } from "../../util/guards.js";
 
 const JUSTIN_THEME_CHANCE = 1;
 const TOXIC_THEME_CHANCE = 1;
@@ -11,6 +12,7 @@ export const TOXIC_FILE_PATH = `${PROJECT_DIR}/audio/toxic.mp3`;
 @Discord()
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 abstract class PeopleThemes {
+	@Guard(BD5Only)
 	@On({ event: "voiceStateUpdate" })
 	private async tryPlayThemes([oldState, newState]: ArgsOf<"voiceStateUpdate">) {
 		await tryPlayPersonTheme(

--- a/src/util/guards.ts
+++ b/src/util/guards.ts
@@ -1,10 +1,29 @@
 import { GuardFunction } from "discordx";
+import { BD5_ID } from "../constants.js";
 import { isNullOrUndefined } from "./general.js";
 
-// Guard function, used for events (@On) that should only execute in guilds
-export const GuildOnly: GuardFunction = (p, c, next) => {
-	if (isNullOrUndefined(p) || p.length === 0 || isNullOrUndefined(p[0]?.guild)) {
+// Resolves guildId from either an event args array (@On) or a direct interaction object (@Slash).
+// Falls back to .guild.id for types that lack a .guildId shorthand (e.g. VoiceState, Presence).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractGuildId(params: unknown): string | null | undefined {
+	const target: any = Array.isArray(params) ? params[0] : params;
+	return target?.guildId ?? target?.guild?.id;
+}
+
+// Guard: block execution in DMs — only run in guilds.
+// For @On() event handlers only. Params is the array of event args, e.g. [message].
+export const GuildOnly: GuardFunction = (params, _client, next) => {
+	if (isNullOrUndefined(params) || params.length === 0 || isNullOrUndefined(params[0]?.guild)) {
 		return false;
 	}
+	return next();
+};
+
+// Guard: only run inside the BD5 server.
+// Works with @On() event handlers and @Slash() / @ContextMenu() commands.
+// For @On(), params is the array of event args (e.g. [message], [oldState, newState]).
+// For @Slash() / @ContextMenu(), params is the interaction object directly.
+export const BD5Only: GuardFunction = (params, _client, next) => {
+	if (extractGuildId(params) !== BD5_ID) return false;
 	return next();
 };

--- a/src/util/guards.ts
+++ b/src/util/guards.ts
@@ -2,14 +2,6 @@ import { GuardFunction } from "discordx";
 import { BD5_ID } from "../constants.js";
 import { isNullOrUndefined } from "./general.js";
 
-// Resolves guildId from either an event args array (@On) or a direct interaction object (@Slash).
-// Falls back to .guild.id for types that lack a .guildId shorthand (e.g. VoiceState, Presence).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractGuildId(params: unknown): string | null | undefined {
-	const target: any = Array.isArray(params) ? params[0] : params;
-	return target?.guildId ?? target?.guild?.id;
-}
-
 // Guard: block execution in DMs — only run in guilds.
 // For @On() event handlers only. Params is the array of event args, e.g. [message].
 export const GuildOnly: GuardFunction = (params, _client, next) => {
@@ -20,10 +12,15 @@ export const GuildOnly: GuardFunction = (params, _client, next) => {
 };
 
 // Guard: only run inside the BD5 server.
-// Works with @On() event handlers and @Slash() / @ContextMenu() commands.
-// For @On(), params is the array of event args (e.g. [message], [oldState, newState]).
-// For @Slash() / @ContextMenu(), params is the interaction object directly.
+// For @On() event handlers only. Params is the array of event args, e.g. [message].
 export const BD5Only: GuardFunction = (params, _client, next) => {
-	if (extractGuildId(params) !== BD5_ID) return false;
+	if (isNullOrUndefined(params) || params.length === 0) {
+		return false;
+	}
+	// Fallback to .guild.id for types lacking a direct .guildId property (VoiceState, Presence)
+	const guildId = params[0]?.guildId ?? params[0]?.guild?.id;
+	if (guildId !== BD5_ID) {
+		return false;
+	}
 	return next();
 };


### PR DESCRIPTION
## Summary

Adds a `BD5Only` discordx `GuardFunction` to `src/util/guards.ts` and applies it via `@Guard(BD5Only)` to the three event handlers that were previously gating themselves with inline `if (guild.id !== BD5_ID) return;` checks. This centralises the BD5 server check into a single reusable pattern, consistent with how `GuildOnly` already works in the codebase.

## Changes

- `src/util/guards.ts`: Add `BD5Only` guard. Uses `p[0]?.guild?.id ?? p[0]?.guildId` to cover both `VoiceState`/`Presence` (`.guild.id`) and `Message` (`.guildId`) event arg shapes.
- `src/events/messageCreate/khang-neko.ts`: Replace `msg.guildId !== BD5_ID` branch with `@Guard(BD5Only)`. Removed `BD5_ID` import.
- `src/events/presenceUpdate/holiday-colors.ts`: Replace `oldPresence.guild.id !== BD5_ID` check with `@Guard(BD5Only)`. `BD5_ID` import retained (still used in `resetAllMembersHolidayColors` and `giveAllMembersHolidayColors`).
- `src/events/voiceStateUpdate/good-night.ts`: Replace `newState.guild.id !== BD5_ID` branch with `@Guard(BD5Only)`. Removed `BD5_ID` import.

## Testing Notes

Connect the dev bot to a server that is **not** BD5 and verify:
- Sending messages in that server (even as Khang) produces no neko reaction from the bot.
- Presence changes do not trigger holiday color role assignments.
- Leaving a voice channel late at night does not trigger a good night message.

Then verify normal BD5 behaviour is unchanged when using the dev bot in the BD5 dev server.

Closes #69